### PR TITLE
step04: remove kubectl config view with wrong output

### DIFF
--- a/step04/README.md
+++ b/step04/README.md
@@ -294,9 +294,6 @@ ubuntu@ip-172-31-30-5:~/kubecon-eu-2019$ kubectl config current-context
 arn:aws:eks:eu-central-1:433017611331:cluster/eks-cloud-native-dev
 
 ubuntu@ip-172-31-30-5:~/kubecon-eu-2019$ kubectl config view
-
-arn:aws:eks:eu-central-1:433017611331:cluster/eks-cloud-native-dev
-ubuntu@ip-172-31-30-5:~/kubecon-eu-2019$ kubectl config view
 apiVersion: v1
 clusters:
 - cluster:


### PR DESCRIPTION
In the Step n°04, there is a `kubectl config view` with output from the previous `kubectl config current-context`. I think it shouldn't be there since the `kubectl config view` with the correct output is right after this.