### PR TITLE
Fixed the Prometheus target in the configmap

### DIFF
--- a/step06/prometheus/templates/prometheus-configMap.yaml
+++ b/step06/prometheus/templates/prometheus-configMap.yaml
@@ -27,5 +27,5 @@ data:
           - '{kubernetes_namespace="{{ .Values.metadata.namespace }}"}'
       static_configs:
         - targets:
-          - 'prometheus-master.kube-system.svc.cluster.local:9090'
+          - 'localhost:9090'
 {{- end -}}


### PR DESCRIPTION
The configmap for Prometheus is wrong for the given configuration, resulting in no data shown on grafana. This PR corrects it